### PR TITLE
Enhanced CollectLibraries

### DIFF
--- a/src/main/kotlin/com/intershop/gradle/icm/tasks/CollectLibraries.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/tasks/CollectLibraries.kt
@@ -81,7 +81,8 @@ open class CollectLibraries : DefaultTask() {
 
         val conflicts = deps.filter { e -> 1 < e.value.size }.map { it.value }.toList()
         if (!conflicts.isEmpty()) {
-            throw GradleException("Unable to process libraries. Dependencies ${conflicts} are required by cartridge-projects in non-unique versions.")
+            throw GradleException("Unable to process libraries. Dependencies ${conflicts}" +
+                    " are required by cartridge-projects in non-unique versions.")
         }
 
         // ensure ids for a certain EnvironmentType only contain ids of this type not others

--- a/src/main/kotlin/com/intershop/gradle/icm/tasks/WriteCartridgeDescriptor.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/tasks/WriteCartridgeDescriptor.kt
@@ -119,7 +119,7 @@ open class WriteCartridgeDescriptor
         flattenToString(
             {
                 project.configurations.getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME).resolvedConfiguration
-                    .lenientConfiguration.firstLevelModuleDependencies
+                    .lenientConfiguration.allModuleDependencies
             },
             { value ->
                 value.toString().apply {


### PR DESCRIPTION
- if dependencies have to be resolved to multiple version an error is raised
- WriteCartridgeDescriptor was wrongly skipped if transitive dependencies changed e.g. due to new version constraints on implicitly dependent libraries