### PR TITLE
70302-EnsureLeafCartridgesAreBuiltOnDbPrepare

### DIFF
--- a/src/main/kotlin/com/intershop/gradle/icm/ICMBasePlugin.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/ICMBasePlugin.kt
@@ -72,6 +72,7 @@ open class ICMBasePlugin: Plugin<Project> {
 
                 // apply maven publishing plugin to root and subprojects
                 plugins.apply(MavenPublishPlugin::class.java)
+                plugins.apply(BasePlugin::class.java)
 
                 val extension = extensions.findByType(
                     IntershopExtension::class.java
@@ -160,7 +161,9 @@ open class ICMBasePlugin: Plugin<Project> {
             }
         }
         // root.assemble dependsOn collectLibrariesTask
-        project.tasks.named(BasePlugin.ASSEMBLE_TASK_NAME).get().dependsOn(collectLibrariesTask)
+        project.tasks.named(BasePlugin.ASSEMBLE_TASK_NAME).configure { rootAssemble ->
+            rootAssemble.dependsOn(collectLibrariesTask)
+        }
 
         return collectLibrariesTask
     }

--- a/src/main/kotlin/com/intershop/gradle/icm/cartridge/CartridgePlugin.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/cartridge/CartridgePlugin.kt
@@ -67,7 +67,6 @@ open class CartridgePlugin : Plugin<Project> {
     private fun configureAddFileCreation(project: Project) {
         with(project) {
             val implementation = configurations.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
-            val runtime = configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
 
             val cartridge = configurations.maybeCreate(CONFIGURATION_CARTRIDGE)
             cartridge.isTransitive = false
@@ -83,11 +82,10 @@ open class CartridgePlugin : Plugin<Project> {
                     WriteCartridgeDescriptor::class.java) { writeCartridgeDescriptor ->
 
                 writeCartridgeDescriptor.dependsOn(cartridge, cartridgeRuntime)
-
-                // cartridge.assemble dependsOn writeCartridgeDescriptor
-                tasks.named(BasePlugin.ASSEMBLE_TASK_NAME).get().dependsOn(writeCartridgeDescriptor)
             }
 
+            // ensure resulting dependency chain (simplified):
+            //     assemble -> jar -> processResources -> writeCartridgeDescriptor
             prTask.configure {
                 it.dependsOn(taskWriteCartridgeDescriptor)
                 it.from(taskWriteCartridgeDescriptor) { cs ->


### PR DESCRIPTION
#70302:
- `root.assemble` is now dependent from `collectLibraries` and `<all cartridges>.assemble`