### PR TITLE
feat: Write cartridge descriptor task configuration cache compatibility

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@
 # These specs are intentionally structurally similar: each one exercises the
 # same cache-hit / cache-miss / cross-directory pattern for a different task.
 # The duplication is inherent to the test design and not a quality issue.
-sonar.cpd.exclusions=src/test/groovy/com/intershop/gradle/icm/cacheability/**
+sonar.cpd.exclusions=**/com/intershop/gradle/icm/cacheability/**

--- a/src/main/kotlin/com/intershop/gradle/icm/tasks/WriteCartridgeDescriptor.kt
+++ b/src/main/kotlin/com/intershop/gradle/icm/tasks/WriteCartridgeDescriptor.kt
@@ -60,12 +60,6 @@ open class WriteCartridgeDescriptor
         const val CARTRIDGE_DESCRIPTOR = "descriptor/cartridge.descriptor"
     }
 
-    // Configurations and DependencyHandler captured at configuration time to avoid calling task.project at execution time
-    private val cartridgeConfiguration: Configuration = project.configurations.getByName(CONFIGURATION_CARTRIDGE)
-    private val cartridgeRuntimeConfiguration: Configuration = project.configurations.getByName(CONFIGURATION_CARTRIDGE_RUNTIME)
-    private val runtimeClasspathConfiguration: Configuration = project.configurations.getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME)
-    private val storedDependencyHandler: DependencyHandler = project.dependencies
-
     /**
      * Set property for descriptor cartridge name property.
      *
@@ -89,30 +83,25 @@ open class WriteCartridgeDescriptor
     val cartridgeStyle: Property<String> = objectFactory.property(String::class.java)
 
     @get:Input
-    val cartridgeDependencies: String by lazy {
-        flattenToString(
-            { cartridgeConfiguration.dependencies },
-            { value ->
-                value.toString().apply {
-                    logger.debug("CartridgeDependencies of cartridge {}: {}", cartridgeName.get(), this)
-                }
-            }
-        )
-    }
+    val cartridgeDependencies: Property<String> = objectFactory.property(String::class.java)
 
     @get:Input
-    val runtimeDependencies: String by lazy {
-        flattenToString(
-            {
-                runtimeClasspathConfiguration.resolvedConfiguration.lenientConfiguration.allModuleDependencies
-            },
-            { value ->
-                value.toString().apply {
-                    logger.debug("RuntimeDependencies of cartridge {}: {}", cartridgeName.get(), this)
-                }
-            }
-        )
-    }
+    val runtimeDependencies: Property<String> = objectFactory.property(String::class.java)
+
+    /**
+     * Pre-computed value for the `cartridge.dependsOn` descriptor entry (semicolon-separated
+     * sorted cartridge IDs resolved from the cartridgeRuntime configuration).
+     */
+    @get:Input
+    val cartridgeDependsOn: Property<String> = objectFactory.property(String::class.java)
+
+    /**
+     * Pre-computed value for the `cartridge.dependsOnLibs` descriptor entry (semicolon-separated
+     * sorted library IDs resolved from the runtimeClasspath configuration, excluding libraries
+     * already provided by cartridge dependencies).
+     */
+    @get:Input
+    val cartridgeDependsOnLibs: Property<String> = objectFactory.property(String::class.java)
 
     /**
      * Output file for generated descriptor.
@@ -133,10 +122,51 @@ open class WriteCartridgeDescriptor
         cartridgeVersion.convention(project.version.toString())
 
         cartridgeStyle.convention(CartridgeUtil.getCartridgeStyle(project).name)
+
+        val cartridgeConfiguration = project.configurations.getByName(CONFIGURATION_CARTRIDGE)
+        val cartridgeRuntimeConfiguration = project.configurations.getByName(CONFIGURATION_CARTRIDGE_RUNTIME)
+        val runtimeClasspathConfiguration = project.configurations.getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+        val dependencyHandler = project.dependencies
+
+        cartridgeDependencies.convention(project.provider {
+            flattenToString(
+                { cartridgeConfiguration.dependencies },
+                { value ->
+                    value.toString().apply {
+                        logger.debug("CartridgeDependencies of cartridge {}: {}", cartridgeName.get(), this)
+                    }
+                }
+            )
+        })
+
+        runtimeDependencies.convention(project.provider {
+            flattenToString(
+                {
+                    runtimeClasspathConfiguration.resolvedConfiguration.lenientConfiguration.allModuleDependencies
+                },
+                { value ->
+                    value.toString().apply {
+                        logger.debug("RuntimeDependencies of cartridge {}: {}", cartridgeName.get(), this)
+                    }
+                }
+            )
+        })
+
+        cartridgeDependsOn.convention(project.provider {
+            val cartDeps = getCartridgeDependencies(cartridgeRuntimeConfiguration, dependencyHandler)
+            cartDeps.map { it.cartridgeId }.toSortedSet().joinToString(separator = ";")
+        })
+
+        cartridgeDependsOnLibs.convention(project.provider {
+            val cartDeps = getCartridgeDependencies(cartridgeRuntimeConfiguration, dependencyHandler)
+            getLibs(cartDeps, runtimeClasspathConfiguration, dependencyHandler).toSortedSet().joinToString(separator = ";")
+        })
     }
 
     /**
      * Task method for the creation of a descriptor file.
+     * All resolution has already happened at configuration time via the @Input properties;
+     * this action only reads pre-computed String values.
      */
     @TaskAction
     fun runFileCreation() {
@@ -147,14 +177,10 @@ open class WriteCartridgeDescriptor
         val props = linkedMapOf<String, String>()
         val comment = "Intershop descriptor file"
 
-        val cartridgeDependencies = getCartridgeDependencies()
-        val libs = getLibs(cartridgeDependencies)
-
         props["descriptor.version"] = "1.0"
 
-        props["cartridge.dependsOn"] = cartridgeDependencies.map { it.cartridgeId }.toSortedSet()
-                .joinToString(separator = ";")
-        props["cartridge.dependsOnLibs"] = libs.toSortedSet().joinToString(separator = ";")
+        props["cartridge.dependsOn"] = cartridgeDependsOn.get()
+        props["cartridge.dependsOnLibs"] = cartridgeDependsOnLibs.get()
 
         props["cartridge.name"] = cartridgeName.get()
         props["cartridge.displayName"] = displayName.get()
@@ -205,7 +231,18 @@ open class WriteCartridgeDescriptor
         return artifacts
     }
 
-    private fun getLibs(cartridgeDependencies: Set<CartridgeDependency>): Set<String> {
+    /**
+     * Computes the set of library IDs that this cartridge directly depends on, excluding any
+     * libraries already provided transitively by its cartridge dependencies.
+     *
+     * Configurations and DependencyHandler are accepted as parameters (not stored as fields)
+     * to keep this method configuration-cache-safe when called from a provider lambda.
+     */
+    private fun getLibs(
+        cartridgeDependencies: Set<CartridgeDependency>,
+        runtimeClasspathConfiguration: Configuration,
+        dependencyHandler: DependencyHandler,
+    ): Set<String> {
         val processedDependencies = mutableSetOf<ResolvedDependency>()
         // put the ids of all cartridge dependencies into 1 single set for later lookup
         val derivedLibraryDependencyIds = cartridgeDependencies.flatMap {
@@ -236,7 +273,7 @@ open class WriteCartridgeDescriptor
                 when (val identifier = artifact.id.componentIdentifier) {
                     is ModuleComponentIdentifier -> {
                         // only add non-cartridge-'jar's
-                        if (artifact.extension.equals("jar") && !CartridgeUtil.isCartridge(storedDependencyHandler, logger, identifier)) {
+                        if (artifact.extension.equals("jar") && !CartridgeUtil.isCartridge(dependencyHandler, logger, identifier)) {
                             val id = "${identifier.group}:${identifier.module}:${identifier.version}"
                             transitiveCount++
                             // only return libs that haven't come along with other cartridges
@@ -254,7 +291,16 @@ open class WriteCartridgeDescriptor
         return dependencies
     }
 
-    private fun getCartridgeDependencies(): Set<CartridgeDependency> {
+    /**
+     * Resolves the first-level cartridge dependencies from [cartridgeRuntimeConfiguration].
+     *
+     * Configurations and DependencyHandler are accepted as parameters (not stored as fields)
+     * to keep this method configuration-cache-safe when called from a provider lambda.
+     */
+    private fun getCartridgeDependencies(
+        cartridgeRuntimeConfiguration: Configuration,
+        dependencyHandler: DependencyHandler,
+    ): Set<CartridgeDependency> {
         val dependencies = HashSet<CartridgeDependency>()
         val resolvedConfig = cartridgeRuntimeConfiguration.resolvedConfiguration
         // ensure build fails if there are resolve errors
@@ -267,7 +313,7 @@ open class WriteCartridgeDescriptor
                     is ProjectComponentIdentifier ->
                         dependencies.add(CartridgeDependency(identifier.projectName, dependency.children))
                     is ModuleComponentIdentifier ->
-                        if (CartridgeUtil.isCartridge(storedDependencyHandler, logger, identifier)) {
+                        if (CartridgeUtil.isCartridge(dependencyHandler, logger, identifier)) {
                             dependencies.add(CartridgeDependency("${identifier.module}:${identifier.version}",
                                     dependency.children))
                         }

--- a/src/test/groovy/com/intershop/gradle/icm/ICMBasePluginIntegrationKotlinSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/icm/ICMBasePluginIntegrationKotlinSpec.groovy
@@ -17,6 +17,7 @@
 package com.intershop.gradle.icm
 
 import com.intershop.gradle.icm.tasks.CreateServerInfo
+import com.intershop.gradle.icm.util.TestRepo
 import com.intershop.gradle.test.AbstractIntegrationKotlinSpec
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -208,6 +209,72 @@ class ICMBasePluginIntegrationKotlinSpec extends AbstractIntegrationKotlinSpec {
         resultpub.task(':prjCartridge_prod:publish').outcome == SUCCESS
 
         resultpub.task(':prjCartridge_test:publish') == null
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
+    def 'writeCartridgeDescriptor writes correct cartridge.dependsOn and cartridge.dependsOnLibs'() {
+        given:
+        TestRepo repo = new TestRepo(new File(testProjectDir, '/repo'))
+        String repoConf = repo.getRepoKtsConfig()
+
+        settingsFile << """
+            rootProject.name = "rootproject"
+            include("prjCartridge_prod")
+        """.stripIndent()
+
+        // Root project only needs the base plugin, repositories live in the sub-project
+        buildFile << """
+            plugins {
+                id("com.intershop.gradle.icm.base")
+            }
+            group   = "com.intershop.test"
+            version = "1.0.0"
+        """.stripIndent()
+
+        def prjDir = createSubProject('prjCartridge_prod', """
+            plugins {
+                `java`
+                id("com.intershop.icm.cartridge.product")
+            }
+
+            ${repoConf}
+
+            dependencies {
+                // external cartridge → drives cartridge.dependsOn
+                add("cartridge", "com.intershop.cartridge:cartridge_prod:1.0.0")
+                // library NOT transitively provided by cartridge_prod → drives cartridge.dependsOnLibs
+                implementation("com.other:library1:1.5.0")
+            }
+        """.stripIndent())
+
+        writeJavaTestClass('com.intershop.prod', prjDir)
+
+        when:
+        def result = getPreparedGradleRunner()
+                .withArguments(':prjCartridge_prod:writeCartridgeDescriptor', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'Task succeeds'
+        result.task(':prjCartridge_prod:writeCartridgeDescriptor').outcome == SUCCESS
+
+        and: 'The descriptor file is generated'
+        def descriptorFile = new File(testProjectDir, 'prjCartridge_prod/build/descriptor/cartridge.descriptor')
+        descriptorFile.exists()
+
+        and: 'cartridge.dependsOn lists the external cartridge'
+        def props = new Properties()
+        props.load(new FileInputStream(descriptorFile))
+        props.getProperty('cartridge.dependsOn') == 'cartridge_prod:1.0.0'
+
+        and: 'cartridge.dependsOnLibs contains library1 (not covered by the cartridge)'
+        props.getProperty('cartridge.dependsOnLibs').contains('com.other:library1:1.5.0')
+
+        and: 'cartridge.dependsOnLibs does NOT contain library2/library3 (provided transitively by cartridge_prod)'
+        !props.getProperty('cartridge.dependsOnLibs').contains('com.other:library2:1.5.0')
+        !props.getProperty('cartridge.dependsOnLibs').contains('com.other:library3:1.5.0')
+
         where:
         gradleVersion << supportedGradleVersions
     }

--- a/src/test/groovy/com/intershop/gradle/icm/ICMBasePluginIntegrationKotlinSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/icm/ICMBasePluginIntegrationKotlinSpec.groovy
@@ -16,12 +16,12 @@
  */
 package com.intershop.gradle.icm
 
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
+
 import com.intershop.gradle.icm.tasks.CreateServerInfo
 import com.intershop.gradle.icm.util.TestRepo
 import com.intershop.gradle.test.AbstractIntegrationKotlinSpec
-
-import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
-import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE 
 
 class ICMBasePluginIntegrationKotlinSpec extends AbstractIntegrationKotlinSpec {
 

--- a/src/test/groovy/com/intershop/gradle/icm/cacheability/AbstractCacheabilitySpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/icm/cacheability/AbstractCacheabilitySpec.groovy
@@ -83,6 +83,49 @@ abstract class AbstractCacheabilitySpec extends AbstractIntegrationKotlinSpec {
     }
 
     /**
+     * Sets up a single-cartridge build that includes an external cartridge dependency
+     * ({@code com.intershop.cartridge:cartridge_prod:1.0.0}) and a direct library dependency
+     * ({@code com.other:library1:1.5.0}) backed by a local Maven repo created via {@link TestRepo}.
+     *
+     * <ul>
+     *   <li>{@code cartridge.dependsOn} should resolve to {@code cartridge_prod:1.0.0}</li>
+     *   <li>{@code cartridge.dependsOnLibs} should contain {@code com.other:library1:1.5.0}
+     *       but NOT {@code library2} / {@code library3} which are transitively provided by
+     *       {@code cartridge_prod}</li>
+     * </ul>
+     */
+    protected void prepareSingleCartridgeBuildWithDependencies() {
+        TestRepo repo = new TestRepo(new File(testProjectDir, "/repo"))
+        String repoConf = repo.getRepoKtsConfig()
+
+        settingsFile.text = """
+            ${buildCacheBlock()}
+            rootProject.name = "testCartridge"
+        """.stripIndent()
+
+        buildFile.text = """
+            plugins {
+                `java`
+                id("com.intershop.icm.cartridge.product")
+            }
+
+            group = "com.intershop.test"
+            version = "1.0.0"
+
+            ${repoConf}
+
+            dependencies {
+                // external cartridge: drives cartridge.dependsOn in the descriptor
+                add("cartridge", "com.intershop.cartridge:cartridge_prod:1.0.0")
+                // library NOT provided by cartridge_prod: drives cartridge.dependsOnLibs
+                implementation("com.other:library1:1.5.0")
+            }
+        """.stripIndent()
+
+        writeJavaTestClass("com.intershop.test", testProjectDir)
+    }
+
+    /**
      * Sets up a full multi-cartridge project build using the
      * {@code com.intershop.gradle.icm.project} plugin with three sub-projects
      * (test, development, adapter cartridges) backed by a local Maven

--- a/src/test/groovy/com/intershop/gradle/icm/cacheability/WriteCartridgeDescriptorCacheabilityKtsSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/icm/cacheability/WriteCartridgeDescriptorCacheabilityKtsSpec.groovy
@@ -7,9 +7,13 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 /**
  * Integration tests to verify that the {@code writeCartridgeDescriptor} task
- * is properly build cache compatible.
+ * is properly build cache and configuration cache compatible.
  */
 class WriteCartridgeDescriptorCacheabilityKtsSpec extends AbstractCacheabilitySpec {
+
+    // -------------------------------------------------------------------------
+    // Build-cache compatibility
+    // -------------------------------------------------------------------------
 
     def 'writeCartridgeDescriptor task should be loaded from cache on second build'() {
         given:
@@ -111,6 +115,103 @@ class WriteCartridgeDescriptorCacheabilityKtsSpec extends AbstractCacheabilitySp
 
         then: 'Task is loaded from cache because the original inputs are restored'
         result3.task(':writeCartridgeDescriptor').outcome == FROM_CACHE
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
+    def 'writeCartridgeDescriptor task should produce a cache miss when cartridgeDependsOn changes'() {
+        given:
+        prepareSingleCartridgeBuildWithDependencies()
+
+        when: 'First build populates the build cache'
+        def result1 = getPreparedGradleRunner()
+            .withArguments('writeCartridgeDescriptor', '--build-cache', '-s')
+            .withGradleVersion(gradleVersion)
+            .build()
+
+        then:
+        result1.task(':writeCartridgeDescriptor').outcome == SUCCESS
+
+        when: 'A second external cartridge dependency is added, changing the cartridgeDependsOn @Input'
+        buildFile.text = buildFile.text.replace(
+            'add("cartridge", "com.intershop.cartridge:cartridge_prod:1.0.0")',
+            '''add("cartridge", "com.intershop.cartridge:cartridge_prod:1.0.0")
+               add("cartridge", "com.intershop.cartridge:cartridge_dev:1.0.0")'''
+        )
+
+        and: 'Task is re-run against the build cache'
+        def result2 = getPreparedGradleRunner()
+            .withArguments('writeCartridgeDescriptor', '--build-cache', '-s')
+            .withGradleVersion(gradleVersion)
+            .build()
+
+        then: 'Task re-executes (cache miss) because cartridgeDependsOn changed'
+        result2.task(':writeCartridgeDescriptor').outcome == SUCCESS
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
+    def 'writeCartridgeDescriptor task should produce a cache miss when cartridgeDependsOnLibs changes'() {
+        given:
+        prepareSingleCartridgeBuildWithDependencies()
+
+        when: 'First build populates the build cache'
+        def result1 = getPreparedGradleRunner()
+            .withArguments('writeCartridgeDescriptor', '--build-cache', '-s')
+            .withGradleVersion(gradleVersion)
+            .build()
+
+        then:
+        result1.task(':writeCartridgeDescriptor').outcome == SUCCESS
+
+        when: 'An additional library dependency is added, changing the cartridgeDependsOnLibs @Input'
+        buildFile.text = buildFile.text.replace(
+            'implementation("com.other:library1:1.5.0")',
+            '''implementation("com.other:library1:1.5.0")
+               implementation("com.other:library4:1.0.0")'''
+        )
+
+        and: 'Task is re-run against the build cache'
+        def result2 = getPreparedGradleRunner()
+            .withArguments('writeCartridgeDescriptor', '--build-cache', '-s')
+            .withGradleVersion(gradleVersion)
+            .build()
+
+        then: 'Task re-executes (cache miss) because cartridgeDependsOnLibs changed'
+        result2.task(':writeCartridgeDescriptor').outcome == SUCCESS
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
+    // -------------------------------------------------------------------------
+    // Configuration-cache compatibility
+    // -------------------------------------------------------------------------
+
+    def 'writeCartridgeDescriptor task should be compatible with the configuration cache'() {
+        given:
+        prepareSingleCartridgeBuild()
+
+        when: 'First build stores the configuration-cache entry'
+        def result1 = getPreparedGradleRunner()
+                .withArguments('writeCartridgeDescriptor', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'Task executes successfully'
+        result1.task(':writeCartridgeDescriptor').outcome == SUCCESS
+        !result1.output.contains('not supported with the configuration cache')
+
+        when: 'Second build runs with the same inputs'
+        def result2 = getPreparedGradleRunner()
+                .withArguments('writeCartridgeDescriptor', '--configuration-cache', '-s')
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then: 'The configuration-cache entry is reused'
+        result2.output.toLowerCase().contains('reusing configuration cache')
 
         where:
         gradleVersion << supportedGradleVersions

--- a/src/test/groovy/com/intershop/gradle/icm/cacheability/WriteCartridgeDescriptorCacheabilityKtsSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/icm/cacheability/WriteCartridgeDescriptorCacheabilityKtsSpec.groovy
@@ -1,9 +1,9 @@
 package com.intershop.gradle.icm.cacheability
 
-import java.nio.file.Files
-
 import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+import java.nio.file.Files
 
 /**
  * Integration tests to verify that the {@code writeCartridgeDescriptor} task


### PR DESCRIPTION
The `WriteCartridgeDescriptor` task has been improved for configuration-cache safety, enhance build cache correctness and add more robust testing. The main changes involve moving dependency resolution and computation logic to two new provider-backed `@Input` properties, updating internal methods to avoid storing configuration-time state and introducing new tests to verify cache behavior and correctness of descriptor outputs.

Fixes also configuration cache errors like:
> Cannot serialize object of type `org.gradle.api.internal.artifacts.configurations.DefaultLegacyConfiguration`, a subtype of `org.gradle.api.artifacts.Configuration`
> - field `cartridgeConfiguration` of `com.intershop.gradle.icm.tasks.WriteCartridgeDescriptor`
> - field `cartridgeRuntimeConfiguration` of `com.intershop.gradle.icm.tasks.WriteCartridgeDescriptor`
> - field `runtimeClasspathConfiguration` of `com.intershop.gradle.icm.tasks.WriteCartridgeDescriptor`

> Cannot serialize object of type `org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler`, a subtype of `org.gradle.api.artifacts.dsl.DependencyHandler`, as these are not supported with the configuration cache.
> - field `storedDependencyHandler` of `com.intershop.gradle.icm.tasks.WriteCartridgeDescriptor`